### PR TITLE
Add 'data' getter for the jvalue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,44 +39,44 @@ pub type jweak = jobject;
 #[repr(C)]
 #[derive(Copy)]
 pub struct jvalue {
-    data: u64,
+    pub _data: u64,
 }
 
 impl jvalue {
     pub unsafe fn z(&mut self) -> *mut jboolean {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn b(&mut self) -> *mut jbyte {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn c(&mut self) -> *mut jchar {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn s(&mut self) -> *mut jshort {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn i(&mut self) -> *mut jint {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn j(&mut self) -> *mut jlong {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn f(&mut self) -> *mut jfloat {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn d(&mut self) -> *mut jdouble {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 
     pub unsafe fn l(&mut self) -> *mut jobject {
-        &mut self.data as *mut _ as *mut _
+        &mut self._data as *mut _ as *mut _
     }
 }
 

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -32,6 +32,9 @@ fn main() {
     );
 
     cfg.skip_type(|s| s == "va_list");
+    cfg.skip_field(|s, field| {
+        s == "jvalue" && field == "_data"
+    });
     cfg.type_name(|s, is_struct| if is_struct && s.ends_with("_") {
         format!("struct {}", s)
     } else {


### PR DESCRIPTION
Compatibility has been broken in the f075705a9b092bfa5fccc01763ad89d352caeb8d commit, because public field becomes private.

Unfortunately `data` field [is used](https://github.com/prevoty/jni-rs/blob/master/src/wrapper/objects/jvalue.rs#L54) in the `jni-rs` crate. I suppose that `trace!` can be useful, so I propose to add getter for the `data` field.