### PR TITLE
Add version constants for Java 9 and 10

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,8 @@ pub const JNI_VERSION_1_2: jint = 0x00010002;
 pub const JNI_VERSION_1_4: jint = 0x00010004;
 pub const JNI_VERSION_1_6: jint = 0x00010006;
 pub const JNI_VERSION_1_8: jint = 0x00010008;
+pub const JNI_VERSION_9: jint = 0x00090000;
+pub const JNI_VERSION_10: jint = 0x000a0000;
 
 #[repr(C)]
 #[derive(Copy)]


### PR DESCRIPTION
The constants JNI_VERSION_9 and JNI_VERSION_10 are missing.

I checked two different Java 11 versions and could not find a constant for Java 11.