### PR TITLE
Add version constants for Java 19, 20, 21

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,8 @@ pub const JNI_VERSION_1_8: jint = 0x00010008;
 pub const JNI_VERSION_9: jint = 0x00090000;
 pub const JNI_VERSION_10: jint = 0x000a0000;
 pub const JNI_VERSION_19: jint = 0x00130000;
+pub const JNI_VERSION_20: jint = 0x00140000;
+pub const JNI_VERSION_21: jint = 0x00150000;
 
 #[repr(C)]
 #[derive(Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub const JNI_VERSION_1_6: jint = 0x00010006;
 pub const JNI_VERSION_1_8: jint = 0x00010008;
 pub const JNI_VERSION_9: jint = 0x00090000;
 pub const JNI_VERSION_10: jint = 0x000a0000;
+pub const JNI_VERSION_19: jint = 0x00130000;
 
 #[repr(C)]
 #[derive(Copy)]


### PR DESCRIPTION
Ref: https://github.com/openjdk/jdk/blob/dc74ea21f104f49c137476142b6f6340fd34af62/src/java.base/share/native/include/jni.h#L1993