### PR TITLE
systest: bump stack size on Windows to avoid overflow

### DIFF
--- a/systest/build.rs
+++ b/systest/build.rs
@@ -22,6 +22,12 @@ fn main() {
     );
     println!("cargo:rustc-link-lib=dylib=jvm");
 
+    // Increase the stack size on Windows otherwise the tests just overflow
+    // the stack.
+    if env::var("CARGO_CFG_TARGET_ENV").unwrap() == "msvc" {
+        println!("cargo:rustc-link-arg=/stack:{}", 8 * 1024 * 1024);
+    }
+
     let mut cfg = ctest2::TestGenerator::new();
 
     let include_dir = java_home.join("include");


### PR DESCRIPTION
With the way the ctest2 test is auto generated then systest will hit a stack overflow with the default Windows stack size. This bumps the stack size to 8MB