### PR TITLE
Add GetModule to JNINativeInterface_

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- GetModule was added to `JNINativeInterface` ([#22](https://github.com/jni-rs/jni-sys/pull/22))
+
+### Fixed
+
+
+### Changed
+
+
+### Removed
+
+
+## [0.3.0] - 2017-07-20
+
+### Changed
+
+- Changed jvalue into a union
+
+[unreleased]: https://github.com/jni-rs/jni-sys/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jni-rs/jni-sys/compare/v0.2.5...v0.3.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1391,6 +1391,7 @@ pub struct JNINativeInterface_ {
         Option<unsafe extern "system" fn(env: *mut JNIEnv, buf: jobject) -> jlong>,
     pub GetObjectRefType:
         Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jobjectRefType>,
+    pub GetModule: Option<unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jobject>,
 }
 
 impl Clone for JNINativeInterface_ {


### PR DESCRIPTION
`GetModule` was added to JNI version 9 so this adds `GetModule` to the end of the `JNINativeInterface_` table

This also adds a `CHANGELOG.md` based on https://keepachangelog.com/en/1.0.0/