### PR TITLE
Make `jboolean` an alias for `bool` instead of `u8`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub type va_list = *mut c_void;
 pub type jint = i32;
 pub type jlong = i64;
 pub type jbyte = i8;
-pub type jboolean = u8;
+pub type jboolean = bool;
 pub type jchar = u16;
 pub type jshort = i16;
 pub type jfloat = f32;
@@ -68,8 +68,8 @@ pub enum jobjectRefType {
     JNIWeakGlobalRefType = 3,
 }
 
-pub const JNI_FALSE: jboolean = 0;
-pub const JNI_TRUE: jboolean = 1;
+pub const JNI_FALSE: jboolean = false;
+pub const JNI_TRUE: jboolean = true;
 
 pub const JNI_OK: jint = 0;
 pub const JNI_ERR: jint = -1;

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -73,5 +73,11 @@ fn main() {
         // dllimport weirdness?
         windows
     });
+    cfg.skip_roundtrip(|s| {
+        matches!(
+            s,
+            "jboolean" // We don't need to be able to roundtrip all possible u8 values for a jboolean, since only 0 are 1 are considered valid.
+        )
+    });
     cfg.header("jni.h").generate("../src/lib.rs", "all.rs");
 }


### PR DESCRIPTION
JNI only strictly defines two valid values for a `jboolean` and there's no consensus on whether other values greater than one will be interpreted as TRUE in all situations.

The safest interpretation is to say that it will lead to undefined behaviour to pass any value besides zero or one as a `jboolean`.

Addresses https://github.com/jni-rs/jni-rs/pull/400
Closes #19