### PR TITLE
Mark JNINativeInterface_ non_exhaustive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,7 @@ pub type JNIEnv = *const JNINativeInterface_;
 pub type JavaVM = *const JNIInvokeInterface_;
 
 #[repr(C)]
+#[non_exhaustive]
 #[derive(Copy)]
 pub struct JNINativeInterface_ {
     pub reserved0: *mut c_void,


### PR DESCRIPTION
It seems unlikely that applications ever destructure JNINativeInterface_ but still good to be clear that, in terms of the Rust API, this type may be extended.