### PR TITLE
Removes the Options around the function pointers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,1284 +115,1131 @@ pub struct JNINativeInterface_ {
     pub reserved1: *mut c_void,
     pub reserved2: *mut c_void,
     pub reserved3: *mut c_void,
-    pub GetVersion: Option<unsafe extern "system" fn(env: *mut JNIEnv) -> jint>,
-    pub DefineClass: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            name: *const c_char,
-            loader: jobject,
-            buf: *const jbyte,
-            len: jsize,
-        ) -> jclass,
-    >,
-    pub FindClass:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, name: *const c_char) -> jclass>,
+    pub GetVersion: unsafe extern "system" fn(env: *mut JNIEnv) -> jint,
+    pub DefineClass: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        name: *const c_char,
+        loader: jobject,
+        buf: *const jbyte,
+        len: jsize,
+    ) -> jclass,
+    pub FindClass: unsafe extern "system" fn(env: *mut JNIEnv, name: *const c_char) -> jclass,
     pub FromReflectedMethod:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, method: jobject) -> jmethodID>,
-    pub FromReflectedField:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, field: jobject) -> jfieldID>,
-    pub ToReflectedMethod: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            cls: jclass,
-            methodID: jmethodID,
-            isStatic: jboolean,
-        ) -> jobject,
-    >,
-    pub GetSuperclass: Option<unsafe extern "system" fn(env: *mut JNIEnv, sub: jclass) -> jclass>,
+        unsafe extern "system" fn(env: *mut JNIEnv, method: jobject) -> jmethodID,
+    pub FromReflectedField: unsafe extern "system" fn(env: *mut JNIEnv, field: jobject) -> jfieldID,
+    pub ToReflectedMethod: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        cls: jclass,
+        methodID: jmethodID,
+        isStatic: jboolean,
+    ) -> jobject,
+    pub GetSuperclass: unsafe extern "system" fn(env: *mut JNIEnv, sub: jclass) -> jclass,
     pub IsAssignableFrom:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, sub: jclass, sup: jclass) -> jboolean>,
-    pub ToReflectedField: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            cls: jclass,
-            fieldID: jfieldID,
-            isStatic: jboolean,
-        ) -> jobject,
-    >,
-    pub Throw: Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jthrowable) -> jint>,
-    pub ThrowNew: Option<
+        unsafe extern "system" fn(env: *mut JNIEnv, sub: jclass, sup: jclass) -> jboolean,
+    pub ToReflectedField: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        cls: jclass,
+        fieldID: jfieldID,
+        isStatic: jboolean,
+    ) -> jobject,
+    pub Throw: unsafe extern "system" fn(env: *mut JNIEnv, obj: jthrowable) -> jint,
+    pub ThrowNew:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, msg: *const c_char) -> jint,
-    >,
-    pub ExceptionOccurred: Option<unsafe extern "system" fn(env: *mut JNIEnv) -> jthrowable>,
-    pub ExceptionDescribe: Option<unsafe extern "system" fn(env: *mut JNIEnv)>,
-    pub ExceptionClear: Option<unsafe extern "system" fn(env: *mut JNIEnv)>,
-    pub FatalError: Option<unsafe extern "system" fn(env: *mut JNIEnv, msg: *const c_char) -> !>,
-    pub PushLocalFrame: Option<unsafe extern "system" fn(env: *mut JNIEnv, capacity: jint) -> jint>,
-    pub PopLocalFrame:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, result: jobject) -> jobject>,
-    pub NewGlobalRef: Option<unsafe extern "system" fn(env: *mut JNIEnv, lobj: jobject) -> jobject>,
-    pub DeleteGlobalRef: Option<unsafe extern "system" fn(env: *mut JNIEnv, gref: jobject)>,
-    pub DeleteLocalRef: Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject)>,
-    pub IsSameObject: Option<
+    pub ExceptionOccurred: unsafe extern "system" fn(env: *mut JNIEnv) -> jthrowable,
+    pub ExceptionDescribe: unsafe extern "system" fn(env: *mut JNIEnv),
+    pub ExceptionClear: unsafe extern "system" fn(env: *mut JNIEnv),
+    pub FatalError: unsafe extern "system" fn(env: *mut JNIEnv, msg: *const c_char) -> !,
+    pub PushLocalFrame: unsafe extern "system" fn(env: *mut JNIEnv, capacity: jint) -> jint,
+    pub PopLocalFrame: unsafe extern "system" fn(env: *mut JNIEnv, result: jobject) -> jobject,
+    pub NewGlobalRef: unsafe extern "system" fn(env: *mut JNIEnv, lobj: jobject) -> jobject,
+    pub DeleteGlobalRef: unsafe extern "system" fn(env: *mut JNIEnv, gref: jobject),
+    pub DeleteLocalRef: unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject),
+    pub IsSameObject:
         unsafe extern "system" fn(env: *mut JNIEnv, obj1: jobject, obj2: jobject) -> jboolean,
-    >,
-    pub NewLocalRef: Option<unsafe extern "system" fn(env: *mut JNIEnv, ref_: jobject) -> jobject>,
-    pub EnsureLocalCapacity:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, capacity: jint) -> jint>,
-    pub AllocObject: Option<unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jobject>,
-    pub NewObject: Option<
+    pub NewLocalRef: unsafe extern "system" fn(env: *mut JNIEnv, ref_: jobject) -> jobject,
+    pub EnsureLocalCapacity: unsafe extern "system" fn(env: *mut JNIEnv, capacity: jint) -> jint,
+    pub AllocObject: unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jobject,
+    pub NewObject:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jobject,
-    >,
-    pub NewObjectV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jobject,
-    >,
-    pub NewObjectA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jobject,
-    >,
-    pub GetObjectClass: Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jclass>,
-    pub IsInstanceOf: Option<
+    pub NewObjectV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jobject,
+    pub NewObjectA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jobject,
+    pub GetObjectClass: unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jclass,
+    pub IsInstanceOf:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, clazz: jclass) -> jboolean,
-    >,
-    pub GetMethodID: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            name: *const c_char,
-            sig: *const c_char,
-        ) -> jmethodID,
-    >,
-    pub CallObjectMethod: Option<
+    pub GetMethodID: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        name: *const c_char,
+        sig: *const c_char,
+    ) -> jmethodID,
+    pub CallObjectMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jobject,
-    >,
-    pub CallObjectMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jobject,
-    >,
-    pub CallObjectMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jobject,
-    >,
-    pub CallBooleanMethod: Option<
+    pub CallObjectMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jobject,
+    pub CallObjectMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jobject,
+    pub CallBooleanMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jboolean,
-    >,
-    pub CallBooleanMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jboolean,
-    >,
-    pub CallBooleanMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jboolean,
-    >,
-    pub CallByteMethod: Option<
+    pub CallBooleanMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jboolean,
+
+    pub CallBooleanMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jboolean,
+
+    pub CallByteMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jbyte,
-    >,
-    pub CallByteMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jbyte,
-    >,
-    pub CallByteMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jbyte,
-    >,
-    pub CallCharMethod: Option<
+
+    pub CallByteMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jbyte,
+
+    pub CallByteMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jbyte,
+
+    pub CallCharMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jchar,
-    >,
-    pub CallCharMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jchar,
-    >,
-    pub CallCharMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jchar,
-    >,
-    pub CallShortMethod: Option<
+
+    pub CallCharMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jchar,
+
+    pub CallCharMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jchar,
+
+    pub CallShortMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jshort,
-    >,
-    pub CallShortMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jshort,
-    >,
-    pub CallShortMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jshort,
-    >,
-    pub CallIntMethod: Option<
+
+    pub CallShortMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jshort,
+
+    pub CallShortMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jshort,
+
+    pub CallIntMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jint,
-    >,
-    pub CallIntMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jint,
-    >,
-    pub CallIntMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jint,
-    >,
-    pub CallLongMethod: Option<
+
+    pub CallIntMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jint,
+
+    pub CallIntMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jint,
+
+    pub CallLongMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jlong,
-    >,
-    pub CallLongMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jlong,
-    >,
-    pub CallLongMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jlong,
-    >,
-    pub CallFloatMethod: Option<
+
+    pub CallLongMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jlong,
+
+    pub CallLongMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jlong,
+
+    pub CallFloatMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jfloat,
-    >,
-    pub CallFloatMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jfloat,
-    >,
-    pub CallFloatMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jfloat,
-    >,
-    pub CallDoubleMethod: Option<
+
+    pub CallFloatMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jfloat,
+
+    pub CallFloatMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jfloat,
+
+    pub CallDoubleMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jdouble,
-    >,
-    pub CallDoubleMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jdouble,
-    >,
-    pub CallDoubleMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jdouble,
-    >,
+
+    pub CallDoubleMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jdouble,
+
+    pub CallDoubleMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jdouble,
+
     pub CallVoidMethod:
-        Option<unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...)>,
-    pub CallVoidMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: va_list,
-        ),
-    >,
-    pub CallVoidMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ),
-    >,
-    pub CallNonvirtualObjectMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jobject,
-    >,
-    pub CallNonvirtualObjectMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jobject,
-    >,
-    pub CallNonvirtualObjectMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jobject,
-    >,
-    pub CallNonvirtualBooleanMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jboolean,
-    >,
-    pub CallNonvirtualBooleanMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jboolean,
-    >,
-    pub CallNonvirtualBooleanMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jboolean,
-    >,
-    pub CallNonvirtualByteMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jbyte,
-    >,
-    pub CallNonvirtualByteMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jbyte,
-    >,
-    pub CallNonvirtualByteMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jbyte,
-    >,
-    pub CallNonvirtualCharMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jchar,
-    >,
-    pub CallNonvirtualCharMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jchar,
-    >,
-    pub CallNonvirtualCharMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jchar,
-    >,
-    pub CallNonvirtualShortMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jshort,
-    >,
-    pub CallNonvirtualShortMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jshort,
-    >,
-    pub CallNonvirtualShortMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jshort,
-    >,
-    pub CallNonvirtualIntMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jint,
-    >,
-    pub CallNonvirtualIntMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jint,
-    >,
-    pub CallNonvirtualIntMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jint,
-    >,
-    pub CallNonvirtualLongMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jlong,
-    >,
-    pub CallNonvirtualLongMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jlong,
-    >,
-    pub CallNonvirtualLongMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jlong,
-    >,
-    pub CallNonvirtualFloatMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jfloat,
-    >,
-    pub CallNonvirtualFloatMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jfloat,
-    >,
-    pub CallNonvirtualFloatMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jfloat,
-    >,
-    pub CallNonvirtualDoubleMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ) -> jdouble,
-    >,
-    pub CallNonvirtualDoubleMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jdouble,
-    >,
-    pub CallNonvirtualDoubleMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jdouble,
-    >,
-    pub CallNonvirtualVoidMethod: Option<
-        unsafe extern "C" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            ...
-        ),
-    >,
-    pub CallNonvirtualVoidMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ),
-    >,
-    pub CallNonvirtualVoidMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            obj: jobject,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ),
-    >,
-    pub GetFieldID: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            name: *const c_char,
-            sig: *const c_char,
-        ) -> jfieldID,
-    >,
-    pub GetObjectField: Option<
+        unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...),
+    pub CallVoidMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: va_list,
+    ),
+
+    pub CallVoidMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ),
+
+    pub CallNonvirtualObjectMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jobject,
+
+    pub CallNonvirtualObjectMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jobject,
+
+    pub CallNonvirtualObjectMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jobject,
+
+    pub CallNonvirtualBooleanMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jboolean,
+
+    pub CallNonvirtualBooleanMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jboolean,
+
+    pub CallNonvirtualBooleanMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jboolean,
+
+    pub CallNonvirtualByteMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jbyte,
+
+    pub CallNonvirtualByteMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jbyte,
+
+    pub CallNonvirtualByteMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jbyte,
+
+    pub CallNonvirtualCharMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jchar,
+
+    pub CallNonvirtualCharMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jchar,
+
+    pub CallNonvirtualCharMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jchar,
+
+    pub CallNonvirtualShortMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jshort,
+
+    pub CallNonvirtualShortMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jshort,
+
+    pub CallNonvirtualShortMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jshort,
+
+    pub CallNonvirtualIntMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jint,
+
+    pub CallNonvirtualIntMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jint,
+
+    pub CallNonvirtualIntMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jint,
+
+    pub CallNonvirtualLongMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jlong,
+
+    pub CallNonvirtualLongMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jlong,
+
+    pub CallNonvirtualLongMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jlong,
+
+    pub CallNonvirtualFloatMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jfloat,
+
+    pub CallNonvirtualFloatMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jfloat,
+
+    pub CallNonvirtualFloatMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jfloat,
+
+    pub CallNonvirtualDoubleMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ) -> jdouble,
+
+    pub CallNonvirtualDoubleMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jdouble,
+
+    pub CallNonvirtualDoubleMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jdouble,
+
+    pub CallNonvirtualVoidMethod: unsafe extern "C" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        ...
+    ),
+
+    pub CallNonvirtualVoidMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ),
+
+    pub CallNonvirtualVoidMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        obj: jobject,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ),
+
+    pub GetFieldID: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        name: *const c_char,
+        sig: *const c_char,
+    ) -> jfieldID,
+
+    pub GetObjectField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jobject,
-    >,
-    pub GetBooleanField: Option<
+
+    pub GetBooleanField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jboolean,
-    >,
-    pub GetByteField: Option<
+
+    pub GetByteField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jbyte,
-    >,
-    pub GetCharField: Option<
+
+    pub GetCharField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jchar,
-    >,
-    pub GetShortField: Option<
+
+    pub GetShortField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jshort,
-    >,
-    pub GetIntField: Option<
+
+    pub GetIntField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jint,
-    >,
-    pub GetLongField: Option<
+
+    pub GetLongField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jlong,
-    >,
-    pub GetFloatField: Option<
+
+    pub GetFloatField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jfloat,
-    >,
-    pub GetDoubleField: Option<
+
+    pub GetDoubleField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID) -> jdouble,
-    >,
-    pub SetObjectField: Option<
+
+    pub SetObjectField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jobject),
-    >,
-    pub SetBooleanField: Option<
+
+    pub SetBooleanField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jboolean),
-    >,
-    pub SetByteField: Option<
+
+    pub SetByteField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jbyte),
-    >,
-    pub SetCharField: Option<
+
+    pub SetCharField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jchar),
-    >,
-    pub SetShortField: Option<
+
+    pub SetShortField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jshort),
-    >,
-    pub SetIntField: Option<
+
+    pub SetIntField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jint),
-    >,
-    pub SetLongField: Option<
+
+    pub SetLongField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jlong),
-    >,
-    pub SetFloatField: Option<
+
+    pub SetFloatField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jfloat),
-    >,
-    pub SetDoubleField: Option<
+
+    pub SetDoubleField:
         unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject, fieldID: jfieldID, val: jdouble),
-    >,
-    pub GetStaticMethodID: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            name: *const c_char,
-            sig: *const c_char,
-        ) -> jmethodID,
-    >,
-    pub CallStaticObjectMethod: Option<
+
+    pub GetStaticMethodID: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        name: *const c_char,
+        sig: *const c_char,
+    ) -> jmethodID,
+
+    pub CallStaticObjectMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jobject,
-    >,
-    pub CallStaticObjectMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jobject,
-    >,
-    pub CallStaticObjectMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jobject,
-    >,
-    pub CallStaticBooleanMethod: Option<
+
+    pub CallStaticObjectMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jobject,
+
+    pub CallStaticObjectMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jobject,
+
+    pub CallStaticBooleanMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jboolean,
-    >,
-    pub CallStaticBooleanMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jboolean,
-    >,
-    pub CallStaticBooleanMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jboolean,
-    >,
-    pub CallStaticByteMethod: Option<
+
+    pub CallStaticBooleanMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jboolean,
+
+    pub CallStaticBooleanMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jboolean,
+
+    pub CallStaticByteMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jbyte,
-    >,
-    pub CallStaticByteMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jbyte,
-    >,
-    pub CallStaticByteMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jbyte,
-    >,
-    pub CallStaticCharMethod: Option<
+
+    pub CallStaticByteMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jbyte,
+
+    pub CallStaticByteMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jbyte,
+
+    pub CallStaticCharMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jchar,
-    >,
-    pub CallStaticCharMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jchar,
-    >,
-    pub CallStaticCharMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jchar,
-    >,
-    pub CallStaticShortMethod: Option<
+
+    pub CallStaticCharMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jchar,
+
+    pub CallStaticCharMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jchar,
+
+    pub CallStaticShortMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jshort,
-    >,
-    pub CallStaticShortMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jshort,
-    >,
-    pub CallStaticShortMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jshort,
-    >,
-    pub CallStaticIntMethod: Option<
+
+    pub CallStaticShortMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jshort,
+
+    pub CallStaticShortMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jshort,
+
+    pub CallStaticIntMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jint,
-    >,
-    pub CallStaticIntMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jint,
-    >,
-    pub CallStaticIntMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jint,
-    >,
-    pub CallStaticLongMethod: Option<
+
+    pub CallStaticIntMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jint,
+
+    pub CallStaticIntMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jint,
+
+    pub CallStaticLongMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jlong,
-    >,
-    pub CallStaticLongMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jlong,
-    >,
-    pub CallStaticLongMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jlong,
-    >,
-    pub CallStaticFloatMethod: Option<
+
+    pub CallStaticLongMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jlong,
+
+    pub CallStaticLongMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jlong,
+
+    pub CallStaticFloatMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jfloat,
-    >,
-    pub CallStaticFloatMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jfloat,
-    >,
-    pub CallStaticFloatMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jfloat,
-    >,
-    pub CallStaticDoubleMethod: Option<
+
+    pub CallStaticFloatMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jfloat,
+
+    pub CallStaticFloatMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jfloat,
+
+    pub CallStaticDoubleMethod:
         unsafe extern "C" fn(env: *mut JNIEnv, clazz: jclass, methodID: jmethodID, ...) -> jdouble,
-    >,
-    pub CallStaticDoubleMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ) -> jdouble,
-    >,
-    pub CallStaticDoubleMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ) -> jdouble,
-    >,
+
+    pub CallStaticDoubleMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ) -> jdouble,
+
+    pub CallStaticDoubleMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ) -> jdouble,
+
     pub CallStaticVoidMethod:
-        Option<unsafe extern "C" fn(env: *mut JNIEnv, cls: jclass, methodID: jmethodID, ...)>,
-    pub CallStaticVoidMethodV: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            cls: jclass,
-            methodID: jmethodID,
-            args: va_list,
-        ),
-    >,
-    pub CallStaticVoidMethodA: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            cls: jclass,
-            methodID: jmethodID,
-            args: *const jvalue,
-        ),
-    >,
-    pub GetStaticFieldID: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            name: *const c_char,
-            sig: *const c_char,
-        ) -> jfieldID,
-    >,
-    pub GetStaticObjectField: Option<
+        unsafe extern "C" fn(env: *mut JNIEnv, cls: jclass, methodID: jmethodID, ...),
+    pub CallStaticVoidMethodV: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        cls: jclass,
+        methodID: jmethodID,
+        args: va_list,
+    ),
+
+    pub CallStaticVoidMethodA: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        cls: jclass,
+        methodID: jmethodID,
+        args: *const jvalue,
+    ),
+
+    pub GetStaticFieldID: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        name: *const c_char,
+        sig: *const c_char,
+    ) -> jfieldID,
+
+    pub GetStaticObjectField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jobject,
-    >,
-    pub GetStaticBooleanField: Option<
+
+    pub GetStaticBooleanField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jboolean,
-    >,
-    pub GetStaticByteField: Option<
+
+    pub GetStaticByteField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jbyte,
-    >,
-    pub GetStaticCharField: Option<
+
+    pub GetStaticCharField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jchar,
-    >,
-    pub GetStaticShortField: Option<
+
+    pub GetStaticShortField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jshort,
-    >,
-    pub GetStaticIntField: Option<
+
+    pub GetStaticIntField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jint,
-    >,
-    pub GetStaticLongField: Option<
+
+    pub GetStaticLongField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jlong,
-    >,
-    pub GetStaticFloatField: Option<
+
+    pub GetStaticFloatField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jfloat,
-    >,
-    pub GetStaticDoubleField: Option<
+
+    pub GetStaticDoubleField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID) -> jdouble,
-    >,
-    pub SetStaticObjectField: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            fieldID: jfieldID,
-            value: jobject,
-        ),
-    >,
-    pub SetStaticBooleanField: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            fieldID: jfieldID,
-            value: jboolean,
-        ),
-    >,
-    pub SetStaticByteField: Option<
+
+    pub SetStaticObjectField: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        fieldID: jfieldID,
+        value: jobject,
+    ),
+
+    pub SetStaticBooleanField: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        fieldID: jfieldID,
+        value: jboolean,
+    ),
+
+    pub SetStaticByteField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID, value: jbyte),
-    >,
-    pub SetStaticCharField: Option<
+
+    pub SetStaticCharField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID, value: jchar),
-    >,
-    pub SetStaticShortField: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            fieldID: jfieldID,
-            value: jshort,
-        ),
-    >,
-    pub SetStaticIntField: Option<
+
+    pub SetStaticShortField: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        fieldID: jfieldID,
+        value: jshort,
+    ),
+
+    pub SetStaticIntField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID, value: jint),
-    >,
-    pub SetStaticLongField: Option<
+
+    pub SetStaticLongField:
         unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass, fieldID: jfieldID, value: jlong),
-    >,
-    pub SetStaticFloatField: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            fieldID: jfieldID,
-            value: jfloat,
-        ),
-    >,
-    pub SetStaticDoubleField: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            fieldID: jfieldID,
-            value: jdouble,
-        ),
-    >,
-    pub NewString: Option<
+
+    pub SetStaticFloatField: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        fieldID: jfieldID,
+        value: jfloat,
+    ),
+
+    pub SetStaticDoubleField: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        fieldID: jfieldID,
+        value: jdouble,
+    ),
+
+    pub NewString:
         unsafe extern "system" fn(env: *mut JNIEnv, unicode: *const jchar, len: jsize) -> jstring,
-    >,
-    pub GetStringLength: Option<unsafe extern "system" fn(env: *mut JNIEnv, str: jstring) -> jsize>,
-    pub GetStringChars: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            str: jstring,
-            isCopy: *mut jboolean,
-        ) -> *const jchar,
-    >,
+
+    pub GetStringLength: unsafe extern "system" fn(env: *mut JNIEnv, str: jstring) -> jsize,
+    pub GetStringChars: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        str: jstring,
+        isCopy: *mut jboolean,
+    ) -> *const jchar,
+
     pub ReleaseStringChars:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, str: jstring, chars: *const jchar)>,
-    pub NewStringUTF:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, utf: *const c_char) -> jstring>,
-    pub GetStringUTFLength:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, str: jstring) -> jsize>,
-    pub GetStringUTFChars: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            str: jstring,
-            isCopy: *mut jboolean,
-        ) -> *const c_char,
-    >,
+        unsafe extern "system" fn(env: *mut JNIEnv, str: jstring, chars: *const jchar),
+    pub NewStringUTF: unsafe extern "system" fn(env: *mut JNIEnv, utf: *const c_char) -> jstring,
+    pub GetStringUTFLength: unsafe extern "system" fn(env: *mut JNIEnv, str: jstring) -> jsize,
+    pub GetStringUTFChars: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        str: jstring,
+        isCopy: *mut jboolean,
+    ) -> *const c_char,
+
     pub ReleaseStringUTFChars:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, str: jstring, chars: *const c_char)>,
-    pub GetArrayLength: Option<unsafe extern "system" fn(env: *mut JNIEnv, array: jarray) -> jsize>,
-    pub NewObjectArray: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            len: jsize,
-            clazz: jclass,
-            init: jobject,
-        ) -> jobjectArray,
-    >,
-    pub GetObjectArrayElement: Option<
+        unsafe extern "system" fn(env: *mut JNIEnv, str: jstring, chars: *const c_char),
+    pub GetArrayLength: unsafe extern "system" fn(env: *mut JNIEnv, array: jarray) -> jsize,
+    pub NewObjectArray: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        len: jsize,
+        clazz: jclass,
+        init: jobject,
+    ) -> jobjectArray,
+
+    pub GetObjectArrayElement:
         unsafe extern "system" fn(env: *mut JNIEnv, array: jobjectArray, index: jsize) -> jobject,
-    >,
-    pub SetObjectArrayElement: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jobjectArray,
-            index: jsize,
-            val: jobject,
-        ),
-    >,
-    pub NewBooleanArray:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jbooleanArray>,
-    pub NewByteArray: Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jbyteArray>,
-    pub NewCharArray: Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jcharArray>,
-    pub NewShortArray:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jshortArray>,
-    pub NewIntArray: Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jintArray>,
-    pub NewLongArray: Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jlongArray>,
-    pub NewFloatArray:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jfloatArray>,
-    pub NewDoubleArray:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jdoubleArray>,
-    pub GetBooleanArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbooleanArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jboolean,
-    >,
-    pub GetByteArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbyteArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jbyte,
-    >,
-    pub GetCharArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jcharArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jchar,
-    >,
-    pub GetShortArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jshortArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jshort,
-    >,
-    pub GetIntArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jintArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jint,
-    >,
-    pub GetLongArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jlongArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jlong,
-    >,
-    pub GetFloatArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jfloatArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jfloat,
-    >,
-    pub GetDoubleArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jdoubleArray,
-            isCopy: *mut jboolean,
-        ) -> *mut jdouble,
-    >,
-    pub ReleaseBooleanArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbooleanArray,
-            elems: *mut jboolean,
-            mode: jint,
-        ),
-    >,
-    pub ReleaseByteArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbyteArray,
-            elems: *mut jbyte,
-            mode: jint,
-        ),
-    >,
-    pub ReleaseCharArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jcharArray,
-            elems: *mut jchar,
-            mode: jint,
-        ),
-    >,
-    pub ReleaseShortArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jshortArray,
-            elems: *mut jshort,
-            mode: jint,
-        ),
-    >,
-    pub ReleaseIntArrayElements: Option<
+
+    pub SetObjectArrayElement: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jobjectArray,
+        index: jsize,
+        val: jobject,
+    ),
+
+    pub NewBooleanArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jbooleanArray,
+    pub NewByteArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jbyteArray,
+    pub NewCharArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jcharArray,
+    pub NewShortArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jshortArray,
+    pub NewIntArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jintArray,
+    pub NewLongArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jlongArray,
+    pub NewFloatArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jfloatArray,
+    pub NewDoubleArray: unsafe extern "system" fn(env: *mut JNIEnv, len: jsize) -> jdoubleArray,
+    pub GetBooleanArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbooleanArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jboolean,
+
+    pub GetByteArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbyteArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jbyte,
+
+    pub GetCharArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jcharArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jchar,
+
+    pub GetShortArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jshortArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jshort,
+
+    pub GetIntArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jintArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jint,
+
+    pub GetLongArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jlongArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jlong,
+
+    pub GetFloatArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jfloatArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jfloat,
+
+    pub GetDoubleArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jdoubleArray,
+        isCopy: *mut jboolean,
+    ) -> *mut jdouble,
+
+    pub ReleaseBooleanArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbooleanArray,
+        elems: *mut jboolean,
+        mode: jint,
+    ),
+
+    pub ReleaseByteArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbyteArray,
+        elems: *mut jbyte,
+        mode: jint,
+    ),
+
+    pub ReleaseCharArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jcharArray,
+        elems: *mut jchar,
+        mode: jint,
+    ),
+
+    pub ReleaseShortArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jshortArray,
+        elems: *mut jshort,
+        mode: jint,
+    ),
+
+    pub ReleaseIntArrayElements:
         unsafe extern "system" fn(env: *mut JNIEnv, array: jintArray, elems: *mut jint, mode: jint),
-    >,
-    pub ReleaseLongArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jlongArray,
-            elems: *mut jlong,
-            mode: jint,
-        ),
-    >,
-    pub ReleaseFloatArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jfloatArray,
-            elems: *mut jfloat,
-            mode: jint,
-        ),
-    >,
-    pub ReleaseDoubleArrayElements: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jdoubleArray,
-            elems: *mut jdouble,
-            mode: jint,
-        ),
-    >,
-    pub GetBooleanArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbooleanArray,
-            start: jsize,
-            l: jsize,
-            buf: *mut jboolean,
-        ),
-    >,
-    pub GetByteArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbyteArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jbyte,
-        ),
-    >,
-    pub GetCharArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jcharArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jchar,
-        ),
-    >,
-    pub GetShortArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jshortArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jshort,
-        ),
-    >,
-    pub GetIntArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jintArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jint,
-        ),
-    >,
-    pub GetLongArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jlongArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jlong,
-        ),
-    >,
-    pub GetFloatArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jfloatArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jfloat,
-        ),
-    >,
-    pub GetDoubleArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jdoubleArray,
-            start: jsize,
-            len: jsize,
-            buf: *mut jdouble,
-        ),
-    >,
-    pub SetBooleanArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbooleanArray,
-            start: jsize,
-            l: jsize,
-            buf: *const jboolean,
-        ),
-    >,
-    pub SetByteArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jbyteArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jbyte,
-        ),
-    >,
-    pub SetCharArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jcharArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jchar,
-        ),
-    >,
-    pub SetShortArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jshortArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jshort,
-        ),
-    >,
-    pub SetIntArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jintArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jint,
-        ),
-    >,
-    pub SetLongArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jlongArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jlong,
-        ),
-    >,
-    pub SetFloatArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jfloatArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jfloat,
-        ),
-    >,
-    pub SetDoubleArrayRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jdoubleArray,
-            start: jsize,
-            len: jsize,
-            buf: *const jdouble,
-        ),
-    >,
-    pub RegisterNatives: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            clazz: jclass,
-            methods: *const JNINativeMethod,
-            nMethods: jint,
-        ) -> jint,
-    >,
-    pub UnregisterNatives:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jint>,
-    pub MonitorEnter: Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jint>,
-    pub MonitorExit: Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jint>,
-    pub GetJavaVM:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, vm: *mut *mut JavaVM) -> jint>,
-    pub GetStringRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            str: jstring,
-            start: jsize,
-            len: jsize,
-            buf: *mut jchar,
-        ),
-    >,
-    pub GetStringUTFRegion: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            str: jstring,
-            start: jsize,
-            len: jsize,
-            buf: *mut c_char,
-        ),
-    >,
-    pub GetPrimitiveArrayCritical: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            array: jarray,
-            isCopy: *mut jboolean,
-        ) -> *mut c_void,
-    >,
-    pub ReleasePrimitiveArrayCritical: Option<
+
+    pub ReleaseLongArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jlongArray,
+        elems: *mut jlong,
+        mode: jint,
+    ),
+
+    pub ReleaseFloatArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jfloatArray,
+        elems: *mut jfloat,
+        mode: jint,
+    ),
+
+    pub ReleaseDoubleArrayElements: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jdoubleArray,
+        elems: *mut jdouble,
+        mode: jint,
+    ),
+
+    pub GetBooleanArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbooleanArray,
+        start: jsize,
+        l: jsize,
+        buf: *mut jboolean,
+    ),
+
+    pub GetByteArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbyteArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jbyte,
+    ),
+
+    pub GetCharArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jcharArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jchar,
+    ),
+
+    pub GetShortArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jshortArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jshort,
+    ),
+
+    pub GetIntArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jintArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jint,
+    ),
+
+    pub GetLongArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jlongArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jlong,
+    ),
+
+    pub GetFloatArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jfloatArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jfloat,
+    ),
+
+    pub GetDoubleArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jdoubleArray,
+        start: jsize,
+        len: jsize,
+        buf: *mut jdouble,
+    ),
+
+    pub SetBooleanArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbooleanArray,
+        start: jsize,
+        l: jsize,
+        buf: *const jboolean,
+    ),
+
+    pub SetByteArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jbyteArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jbyte,
+    ),
+
+    pub SetCharArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jcharArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jchar,
+    ),
+
+    pub SetShortArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jshortArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jshort,
+    ),
+
+    pub SetIntArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jintArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jint,
+    ),
+
+    pub SetLongArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jlongArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jlong,
+    ),
+
+    pub SetFloatArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jfloatArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jfloat,
+    ),
+
+    pub SetDoubleArrayRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jdoubleArray,
+        start: jsize,
+        len: jsize,
+        buf: *const jdouble,
+    ),
+
+    pub RegisterNatives: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        clazz: jclass,
+        methods: *const JNINativeMethod,
+        nMethods: jint,
+    ) -> jint,
+
+    pub UnregisterNatives: unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jint,
+    pub MonitorEnter: unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jint,
+    pub MonitorExit: unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jint,
+    pub GetJavaVM: unsafe extern "system" fn(env: *mut JNIEnv, vm: *mut *mut JavaVM) -> jint,
+    pub GetStringRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        str: jstring,
+        start: jsize,
+        len: jsize,
+        buf: *mut jchar,
+    ),
+
+    pub GetStringUTFRegion: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        str: jstring,
+        start: jsize,
+        len: jsize,
+        buf: *mut c_char,
+    ),
+
+    pub GetPrimitiveArrayCritical: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        array: jarray,
+        isCopy: *mut jboolean,
+    ) -> *mut c_void,
+
+    pub ReleasePrimitiveArrayCritical:
         unsafe extern "system" fn(env: *mut JNIEnv, array: jarray, carray: *mut c_void, mode: jint),
-    >,
-    pub GetStringCritical: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            string: jstring,
-            isCopy: *mut jboolean,
-        ) -> *const jchar,
-    >,
+
+    pub GetStringCritical: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        string: jstring,
+        isCopy: *mut jboolean,
+    ) -> *const jchar,
+
     pub ReleaseStringCritical:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, string: jstring, cstring: *const jchar)>,
-    pub NewWeakGlobalRef:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jweak>,
-    pub DeleteWeakGlobalRef: Option<unsafe extern "system" fn(env: *mut JNIEnv, ref_: jweak)>,
-    pub ExceptionCheck: Option<unsafe extern "system" fn(env: *mut JNIEnv) -> jboolean>,
-    pub NewDirectByteBuffer: Option<
-        unsafe extern "system" fn(
-            env: *mut JNIEnv,
-            address: *mut c_void,
-            capacity: jlong,
-        ) -> jobject,
-    >,
+        unsafe extern "system" fn(env: *mut JNIEnv, string: jstring, cstring: *const jchar),
+    pub NewWeakGlobalRef: unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jweak,
+    pub DeleteWeakGlobalRef: unsafe extern "system" fn(env: *mut JNIEnv, ref_: jweak),
+    pub ExceptionCheck: unsafe extern "system" fn(env: *mut JNIEnv) -> jboolean,
+    pub NewDirectByteBuffer: unsafe extern "system" fn(
+        env: *mut JNIEnv,
+        address: *mut c_void,
+        capacity: jlong,
+    ) -> jobject,
+
     pub GetDirectBufferAddress:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, buf: jobject) -> *mut c_void>,
-    pub GetDirectBufferCapacity:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, buf: jobject) -> jlong>,
+        unsafe extern "system" fn(env: *mut JNIEnv, buf: jobject) -> *mut c_void,
+    pub GetDirectBufferCapacity: unsafe extern "system" fn(env: *mut JNIEnv, buf: jobject) -> jlong,
     pub GetObjectRefType:
-        Option<unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jobjectRefType>,
-    pub GetModule: Option<unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jobject>,
+        unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jobjectRefType,
+    pub GetModule: unsafe extern "system" fn(env: *mut JNIEnv, clazz: jclass) -> jobject,
 }
 
 impl Clone for JNINativeInterface_ {
@@ -1461,25 +1308,22 @@ pub struct JNIInvokeInterface_ {
     pub reserved0: *mut c_void,
     pub reserved1: *mut c_void,
     pub reserved2: *mut c_void,
-    pub DestroyJavaVM: Option<unsafe extern "system" fn(vm: *mut JavaVM) -> jint>,
-    pub AttachCurrentThread: Option<
-        unsafe extern "system" fn(
-            vm: *mut JavaVM,
-            penv: *mut *mut c_void,
-            args: *mut c_void,
-        ) -> jint,
-    >,
-    pub DetachCurrentThread: Option<unsafe extern "system" fn(vm: *mut JavaVM) -> jint>,
-    pub GetEnv: Option<
+    pub DestroyJavaVM: unsafe extern "system" fn(vm: *mut JavaVM) -> jint,
+    pub AttachCurrentThread: unsafe extern "system" fn(
+        vm: *mut JavaVM,
+        penv: *mut *mut c_void,
+        args: *mut c_void,
+    ) -> jint,
+
+    pub DetachCurrentThread: unsafe extern "system" fn(vm: *mut JavaVM) -> jint,
+    pub GetEnv:
         unsafe extern "system" fn(vm: *mut JavaVM, penv: *mut *mut c_void, version: jint) -> jint,
-    >,
-    pub AttachCurrentThreadAsDaemon: Option<
-        unsafe extern "system" fn(
-            vm: *mut JavaVM,
-            penv: *mut *mut c_void,
-            args: *mut c_void,
-        ) -> jint,
-    >,
+
+    pub AttachCurrentThreadAsDaemon: unsafe extern "system" fn(
+        vm: *mut JavaVM,
+        penv: *mut *mut c_void,
+        args: *mut c_void,
+    ) -> jint,
 }
 
 impl Clone for JNIInvokeInterface_ {


### PR DESCRIPTION
None of the JNI 1.1 function pointers were optional, and neither are any of the function pointers in later versions of the spec.

Having the `Option` implies that null pointer checks are required but, more notably, they also suggest that null pointer checks could be used for JNI >= 1.2 pointers, which could be a dangerous mistake since these are effectively extending beyond the table of pointers that was defined for JNI 1.1 and should be assumed to be invalid pointers that mustn't be touched.

It's also notable that we sometimes have to call `GetVersion` to determine the full set of pointers that are valid.

Recently the use of `Option` also raised some questions about our ability to, infallibly, handle Rust panics when we want to map a panic to a Java exception via JNI:

https://github.com/jni-rs/jni-rs/issues/432#issuecomment-1470934365

--

For now I've just created this as a draft PR since I also think it could be worth considering changing `JNINativeInterface_` into a union that would look something like:

```rust
union JNINativeInterface_ {
    all: JNINativeInterface_all_,
    1_1: JNINativeInterface_1_1_,
    1_2: JNINativeInterface_1_2_,
    ...
}
```

So then it becomes clearer that you need to access the function pointers according to the known version and in doing so you gain some safety because Rust can stop you from trying to call a JNI 1.2 method while dereferencing the `.1_1` functions.

The `.1_1` table would also include the padding for the reserved `null` functions in the middle of the table but can rename them so it would be harder to accidentally dereference them.