### PR TITLE
Avoid checking more recent version constants in systest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --tests --all-features -- -D warnings
+          args: --all --tests -- -D warnings
 
   # Security audit.
   audit:
@@ -78,12 +78,13 @@ jobs:
       - name: Install java
         uses: actions/setup-java@v1
         with:
-          java-version: '1.8.0'
+          distribution: temurin
+          java-version: '20'
       - name: Build
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --examples --all
+          args: --features=jni19,jni20 --examples --all
       - name: Test default features
         uses: actions-rs/cargo@v1
         with:

--- a/systest/Cargo.toml
+++ b/systest/Cargo.toml
@@ -10,3 +10,8 @@ libc = "0.2"
 
 [build-dependencies]
 ctest2 = "0.4"
+
+[features]
+jni19 = []
+jni20 = []
+jni21 = []

--- a/systest/build.rs
+++ b/systest/build.rs
@@ -34,6 +34,11 @@ fn main() {
     cfg.include(&include_dir)
         .include(include_dir.join(platform_dir));
 
+    cfg.skip_const(|s| {
+        (!cfg!(feature = "jni19") && s == "JNI_VERSION_19")
+            || (!cfg!(feature = "jni20") && s == "JNI_VERSION_20")
+            || (!cfg!(feature = "jni21") && s == "JNI_VERSION_21")
+    });
     cfg.skip_type(|s| s == "va_list");
     cfg.skip_field(|s, field| {
         (s == "jvalue" && field == "_data")


### PR DESCRIPTION
This fixes CI and avoids needing a bleeding edge jni.h

Since [adding the `JNI_VERSION_19` - `_21` constants](https://github.com/jni-rs/jni-sys/pull/15) then `systest` will fail to build, unless these constants are found in `jni.h`.

This adds `jni19,jni20` and `jni21` feature flags for `systest` so we can skip checking for the corresponding JNI_VERSION constants unless we know we have a suitably recent version of Java installed.

CI will now install temurin v20 so it can enable the jni19 and jni20 features.