### PR TITLE
Add GetStringUTFLengthAsLong

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1309,6 +1309,10 @@ pub struct JNINativeInterface_ {
 
     #[jni_added("19")]
     pub IsVirtualThread: unsafe extern "system" fn(env: *mut JNIEnv, obj: jobject) -> jboolean,
+
+    #[jni_added("24")]
+    pub GetStringUTFLengthAsLong:
+        unsafe extern "system" fn(env: *mut JNIEnv, string: jstring) -> jlong,
 }
 
 #[repr(C)]


### PR DESCRIPTION
Added [GetStringUTFLengthAsLong](https://docs.oracle.com/en/java/javase/25/docs/specs/jni/functions.html#getstringutflengthaslong)  introduced with jdk 24 