### PR TITLE
Fix jni_env_union test

### DIFF
--- a/tests/jni-to-union.rs
+++ b/tests/jni-to-union.rs
@@ -40,7 +40,7 @@ fn jni_to_union() {
     );
 }
 
-const NUM_JNI_ENV_MEMBERS: usize = 235;
+const NUM_JNI_ENV_MEMBERS: usize = 236;
 #[test]
 fn jni_env_union() {
     assert_eq!(


### PR DESCRIPTION
This bumps `NUM_JNI_ENV_MEMBERS` in `tests/jni-union.rs` to account for the added `GetStringUTFLengthAsLong` member from #42