### PR TITLE
Add minimal test for invocation API + JNI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         include:
           - build: Linux MSRV
             os: ubuntu-latest
-            rust-version: 1.76.0
+            rust-version: 1.77.0
           - build: Linux
             rust-version: stable
             os: ubuntu-latest
@@ -83,5 +83,7 @@ jobs:
         run: cargo build -p jni-sys
       - name: Test
         run: cargo test -p jni-sys
+        env:
+          _JNI_SYS_TEST: "1"
 
       # Note: we don't currently run systest via CI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ members = ["systest", "jni-sys-macros", "jni-sys"]
 [workspace.package]
 version = "0.4.1"
 authors = [
-  "Steven Fackler <sfackler@gmail.com>",
-  "Robert Bragg <robert@sixbynine.org>",
+    "Steven Fackler <sfackler@gmail.com>",
+    "Robert Bragg <robert@sixbynine.org>",
 ]
 license = "MIT OR Apache-2.0"
 description = "Rust definitions corresponding to jni.h"
@@ -15,10 +15,11 @@ readme = "README.md"
 categories = ["external-ffi-bindings"]
 keywords = ["java", "jni"]
 edition = "2021"
-rust-version = "1.76.0"
+rust-version = "1.77.0"
 exclude = ["/.github"]
 
 [workspace.dependencies]
 jni-sys-macros = { path = "jni-sys-macros" }
 jni-sys = { path = "jni-sys" }
 trybuild = "1"
+thiserror = "2"

--- a/jni-sys/Cargo.toml
+++ b/jni-sys/Cargo.toml
@@ -18,3 +18,4 @@ jni-sys-macros.workspace = true
 
 [dev-dependencies]
 trybuild.workspace = true
+thiserror.workspace = true

--- a/jni-sys/build.rs
+++ b/jni-sys/build.rs
@@ -1,0 +1,35 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(jvm_linked)");
+
+    if option_env!("_JNI_SYS_TEST").is_some() {
+        let java_home = std::env::var("JAVA_HOME").unwrap();
+        println!("cargo:rustc-link-search=native={}/lib/server", java_home);
+        println!("cargo:rustc-link-search=native={}/lib", java_home);
+
+        println!("cargo:rustc-cfg=jvm_linked");
+
+        println!("cargo:rustc-link-lib=dylib=jvm");
+
+        // NB: cargo won't update the system search path for dynamic libraries outside of
+        // the target directory, so we need to set the environment variables for the test
+        // process to find libjvm
+
+        // set LD_LIBRARY_PATH (linux), DYLD_FALLBACK_LIBRARY_PATH (macOS) + PATH (windows) for tests
+        println!("cargo:rustc-env=LD_LIBRARY_PATH={java_home}/lib/server");
+        println!("cargo:rustc-env=DYLD_FALLBACK_LIBRARY_PATH={java_home}/lib/server");
+        let path = std::env::var("PATH").unwrap_or_default();
+        let java_home = std::path::PathBuf::from(java_home);
+        if cfg!(windows) {
+            let windows_jvm_path = java_home.join("bin").join("server");
+            println!(
+                "cargo:rustc-env=PATH={};{}",
+                windows_jvm_path.display(),
+                path
+            );
+        }
+    }
+
+    // Re-run the build script if JAVA_HOME or _JNI_SYS_TEST changes
+    println!("cargo:rerun-if-env-changed=JAVA_HOME");
+    println!("cargo:rerun-if-env-changed=_JNI_SYS_TEST");
+}

--- a/jni-sys/tests/jni.rs
+++ b/jni-sys/tests/jni.rs
@@ -1,0 +1,81 @@
+#![cfg(jvm_linked)]
+
+//! Make sure to set JAVA_HOME and _JNI_SYS_TEST=1 in the environment when
+//! running `cargo test` to link against libjvm.
+
+use std::ptr;
+
+use jni_sys as sys;
+
+#[path = "utils.rs"]
+mod utils;
+
+use utils::*;
+
+#[test]
+fn invocation_jni_test() {
+    unsafe {
+        let jvm = get_java_vm().unwrap();
+
+        let env = attach_current_thread(jvm).unwrap();
+
+        // Find the java.lang.Integer class
+        let integer_class =
+            jni_call_unchecked!(env, v1_1, FindClass, c"java/lang/Integer".as_ptr());
+        assert!(!integer_class.is_null(), "Failed to find Integer class");
+
+        // Get the constructor method ID for Integer(int)
+        let ctor_id = jni_call_unchecked!(
+            env,
+            v1_1,
+            GetMethodID,
+            integer_class,
+            c"<init>".as_ptr(),
+            c"(I)V".as_ptr()
+        );
+        assert!(!ctor_id.is_null(), "Failed to get Integer constructor");
+
+        // Create an Integer object with value 42 using NewObjectA
+        let args = [sys::jvalue { i: 42 }];
+        let integer_obj =
+            jni_call_unchecked!(env, v1_1, NewObjectA, integer_class, ctor_id, args.as_ptr());
+        assert!(!integer_obj.is_null(), "Failed to create Integer object");
+
+        println!("Created Integer object with value 42");
+
+        // Get the intValue() method ID
+        let intvalue_method = jni_call_unchecked!(
+            env,
+            v1_1,
+            GetMethodID,
+            integer_class,
+            c"intValue".as_ptr(),
+            c"()I".as_ptr()
+        );
+        assert!(!intvalue_method.is_null(), "Failed to get intValue method");
+
+        // Call the intValue() method
+        let value = jni_call_unchecked!(
+            env,
+            v1_1,
+            CallIntMethodA,
+            integer_obj,
+            intvalue_method,
+            ptr::null()
+        );
+        if jni_call_unchecked!(env, v1_2, ExceptionCheck) != sys::JNI_FALSE {
+            jni_call_unchecked!(env, v1_1, ExceptionDescribe);
+            jni_call_unchecked!(env, v1_1, ExceptionClear);
+            panic!("JNI exception occurred");
+        }
+        println!("Called intValue() and got: {}", value);
+
+        detach_current_thread(jvm).unwrap();
+
+        // Destroy the JVM
+        let destroy_ret = java_vm_call_unchecked!(jvm, v1_1, DestroyJavaVM);
+        jni_error_code_to_result(destroy_ret).unwrap();
+
+        println!("JVM destroyed successfully");
+    }
+}

--- a/jni-sys/tests/utils.rs
+++ b/jni-sys/tests/utils.rs
@@ -1,0 +1,152 @@
+#![cfg(jvm_linked)]
+#![allow(unused)]
+
+use std::{ffi::c_void, ptr};
+
+use jni_sys as sys;
+use thiserror::Error;
+
+#[macro_export]
+macro_rules! java_vm_call_unchecked {
+    ( $jvm:expr, $version:tt, $name:ident $(, $args:expr )*) => {{
+        let jvm: *mut jni_sys::JavaVM = $jvm;
+        ((*(*jvm)).$version.$name)(jvm $(, $args)*)
+    }};
+}
+
+#[macro_export]
+macro_rules! jni_call_unchecked {
+    ( $jnienv:expr, $version:tt, $name:ident $(, $args:expr )*) => {{
+        let env: *mut jni_sys::JNIEnv = $jnienv;
+        let interface: *const jni_sys::JNINativeInterface_ = *env;
+        ((*interface).$version.$name)(env $(, $args)*)
+    }};
+}
+
+#[derive(Debug, Error)]
+pub enum JniError {
+    #[error("Unknown error")]
+    Unknown,
+    #[error("Current thread is not attached to the Java VM")]
+    ThreadDetached,
+    #[error("JNI version error")]
+    WrongVersion,
+    #[error("Not enough memory")]
+    NoMemory,
+    #[error("VM already created")]
+    AlreadyCreated,
+    #[error("Invalid arguments")]
+    InvalidArguments,
+    #[error("Error code {0}")]
+    Other(sys::jint),
+}
+
+type Result<T> = std::result::Result<T, JniError>;
+
+pub fn jni_error_code_to_result(code: sys::jint) -> Result<()> {
+    match code {
+        sys::JNI_OK => Ok(()),
+        sys::JNI_ERR => Err(JniError::Unknown),
+        sys::JNI_EDETACHED => Err(JniError::ThreadDetached),
+        sys::JNI_EVERSION => Err(JniError::WrongVersion),
+        sys::JNI_ENOMEM => Err(JniError::NoMemory),
+        sys::JNI_EEXIST => Err(JniError::AlreadyCreated),
+        sys::JNI_EINVAL => Err(JniError::InvalidArguments),
+        _ => Err(JniError::Other(code)),
+    }
+}
+
+struct JavaVMWrapper {
+    jvm: *mut sys::JavaVM,
+}
+unsafe impl Send for JavaVMWrapper {}
+unsafe impl Sync for JavaVMWrapper {}
+impl JavaVMWrapper {
+    fn new(jvm: *mut sys::JavaVM) -> Self {
+        Self { jvm }
+    }
+    fn ptr(&self) -> *mut sys::JavaVM {
+        self.jvm
+    }
+}
+static SINGLETON_JVM: std::sync::OnceLock<JavaVMWrapper> = std::sync::OnceLock::new();
+
+pub fn get_java_vm() -> Result<*mut sys::JavaVM> {
+    let jvm = SINGLETON_JVM.get_or_init(|| {
+        let jvm = create_java_vm().expect("Failed to create Java VM");
+        JavaVMWrapper::new(jvm)
+    });
+    Ok(jvm.ptr())
+}
+
+/// Creates a Java VM and returns a pointer to it.
+pub fn create_java_vm() -> Result<*mut sys::JavaVM> {
+    unsafe {
+        let opts: Vec<sys::JavaVMOption> = vec![sys::JavaVMOption {
+            optionString: c"-Xcheck:jni".as_ptr() as _,
+            extraInfo: ptr::null_mut(),
+        }];
+        let args = sys::JavaVMInitArgs {
+            version: sys::JNI_VERSION_1_4,
+            ignoreUnrecognized: jni_sys::JNI_FALSE,
+            options: opts.as_ptr() as _,
+            nOptions: opts.len() as _,
+        };
+
+        let mut jvm: *mut sys::JavaVM = ::std::ptr::null_mut();
+        let mut env: *mut sys::JNIEnv = ::std::ptr::null_mut();
+        let ret = JNI_CreateJavaVM(
+            &mut jvm as *mut _,
+            &mut env as *mut *mut sys::JNIEnv as *mut *mut c_void,
+            &args as *const _ as _,
+        );
+        jni_error_code_to_result(ret)?;
+        Ok(jvm)
+    }
+}
+
+/// Attaches the current thread to the given Java VM and returns the JNI environment pointer.
+///
+/// # Safety
+///
+/// The caller must ensure that `vm` is a valid pointer to a JavaVM
+pub unsafe fn attach_current_thread(vm: *mut sys::JavaVM) -> Result<*mut sys::JNIEnv> {
+    let mut env_ptr = ptr::null_mut();
+
+    let mut args = sys::JavaVMAttachArgs {
+        version: sys::JNI_VERSION_1_4,
+        name: ptr::null_mut(),
+        group: ptr::null_mut(),
+    };
+    let res = unsafe {
+        java_vm_call_unchecked!(
+            vm,
+            v1_1,
+            AttachCurrentThread,
+            &mut env_ptr,
+            &mut args as *mut jni_sys::JavaVMAttachArgs as *mut core::ffi::c_void
+        )
+    };
+    jni_error_code_to_result(res)?;
+
+    Ok(env_ptr as *mut jni_sys::JNIEnv)
+}
+
+/// Detaches the current thread from the given Java VM.
+///
+/// # Safety
+///
+/// The caller must ensure that `vm` is a valid pointer to a JavaVM
+pub unsafe fn detach_current_thread(vm: *mut sys::JavaVM) -> Result<()> {
+    let res = unsafe { java_vm_call_unchecked!(vm, v1_1, DetachCurrentThread) };
+    jni_error_code_to_result(res)
+}
+
+#[link(name = "jvm")]
+extern "system" {
+    pub fn JNI_CreateJavaVM(
+        pvm: *mut *mut sys::JavaVM,
+        penv: *mut *mut c_void,
+        args: *mut c_void,
+    ) -> sys::jint;
+}


### PR DESCRIPTION
This adds a minimal test that uses the invocation API to create a JVM and then uses JNI to look up a class + methodID and make a method call.

This bumps the MSRV to 1.77 so that the tests can use CStr literals