### PR TITLE
Include license files in packages

### DIFF
--- a/jni-sys-macros/LICENSE-APACHE
+++ b/jni-sys-macros/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/jni-sys-macros/LICENSE-MIT
+++ b/jni-sys-macros/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/jni-sys/LICENSE-APACHE
+++ b/jni-sys/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/jni-sys/LICENSE-MIT
+++ b/jni-sys/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Since commit 6fa9eed, the `jni-sys` crate no longer includes license files when built from the repository, and I don't think the `jni-sys-macros` crate ever included license files.  This is a problem for programs like [`cargo-bundle-licenses`](https://crates.io/crates/cargo-bundle-licenses) that inspect crates for licensing information.

This PR fixes this by adding symlinks to the root licenses in each of the package directories.  `cargo release` will replace the symlinks with the actual license file contents when releasing.